### PR TITLE
Add branch label as a CSS class to the corresponding DOM element

### DIFF
--- a/lib/treeviewui.coffee
+++ b/lib/treeviewui.coffee
@@ -229,6 +229,9 @@ module.exports = class TreeViewUI
         if @showBranchLabel and head?
           branchLabel = document.createElement('span')
           branchLabel.classList.add('branch-label')
+          # Check if branch name can be a valid CSS class
+          if /^[a-z_-][a-z\d_-]*$/i.test(head)
+            branchLabel.classList.add(head)
           branchLabel.textContent = head
           display = true
         if @showCommitsAheadLabel and ahead > 0


### PR DESCRIPTION
This enable custom styling based on the branch name.

Example: when you have a big list of projects you might want to add a:

``` CSS
.branch-label:not(.master) {
  color: orange;
}
```

Class to your styles.less to automatically see which project is on a [branch] and which project is on [master].
